### PR TITLE
Account for paused time when ending sessions

### DIFF
--- a/src/main/java/com/oceanami/parkour/listeners/PlayerListener.java
+++ b/src/main/java/com/oceanami/parkour/listeners/PlayerListener.java
@@ -106,7 +106,7 @@ public class PlayerListener implements Listener {
                 if (inCorrectCourse) {
                     long timePaused = totalPausedTime.getOrDefault(player.getUniqueId(), 0L);
                     long timeTaken = (System.currentTimeMillis() - session.startTime() - timePaused) / 1000;
-                    parkourManager.endSession(player, true);
+                    parkourManager.endSession(player, true, timePaused);
                     stopScoreboard(player);
 
                     Component mainTitle = Component.text("Course Completed!", NamedTextColor.GREEN);

--- a/src/main/java/com/oceanami/parkour/manager/ParkourManager.java
+++ b/src/main/java/com/oceanami/parkour/manager/ParkourManager.java
@@ -91,11 +91,15 @@ public class ParkourManager {
     }
 
     public void endSession(Player player, boolean completed) {
+        endSession(player, completed, 0L);
+    }
+
+    public void endSession(Player player, boolean completed, long pausedMillis) {
         ParkourSession session = getSession(player);
         if (session == null) return;
 
         if (completed) {
-            long timeTaken = System.currentTimeMillis() - session.startTime();
+            long timeTaken = System.currentTimeMillis() - session.startTime() - pausedMillis;
             String formattedTime = formatTime(timeTaken);
 
             player.sendMessage(Component.text("You finished the course in ", NamedTextColor.GOLD)


### PR DESCRIPTION
## Summary
- Ensure ParkourManager subtracts paused AFK time when finishing a course
- Pass pause duration from PlayerListener when handling the finish plate

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6896b692c9a48329bcdcbc3e076a4bdb