### PR TITLE
Optimize plate lookup with block-key map

### DIFF
--- a/src/main/java/com/oceanami/parkour/listeners/PlayerListener.java
+++ b/src/main/java/com/oceanami/parkour/listeners/PlayerListener.java
@@ -60,7 +60,7 @@ public class PlayerListener implements Listener {
         Block block = event.getClickedBlock();
         if (block == null || block.getType() != Material.LIGHT_WEIGHTED_PRESSURE_PLATE) return;
 
-        Optional<PlateInfo> plateInfoOptional = locationCache.getPlateInfo(block.getLocation());
+        Optional<PlateInfo> plateInfoOptional = locationCache.getPlateInfo(block);
         if (plateInfoOptional.isEmpty()) return;
 
         PlateInfo plateInfo = plateInfoOptional.get();

--- a/src/main/java/com/oceanami/parkour/manager/BlockKey.java
+++ b/src/main/java/com/oceanami/parkour/manager/BlockKey.java
@@ -1,0 +1,9 @@
+package com.oceanami.parkour.manager;
+
+import java.util.UUID;
+
+/**
+ * Simple key representing a block's position in a world.
+ */
+public record BlockKey(UUID worldId, int x, int y, int z) {
+}


### PR DESCRIPTION
## Summary
- Add `BlockKey` record and direct `plateInfoMap` for fast plate lookups
- Populate map on load and when adding locations; expose `getPlateInfo(Block)`
- Update `PlayerListener` to use new block-based lookup

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden"))*

------
https://chatgpt.com/codex/tasks/task_e_6896c28c7f7483298ecef947c67c155d