### PR TITLE
Run database operations asynchronously

### DIFF
--- a/src/main/java/com/oceanami/parkour/ParkourPlugin.java
+++ b/src/main/java/com/oceanami/parkour/ParkourPlugin.java
@@ -36,7 +36,7 @@ public final class ParkourPlugin extends JavaPlugin {
         this.uiManager = new UIManager(this);
         this.locationCache = new LocationCache(this);
         this.courseCache = new CourseCache(this.databaseManager, getLogger());
-        this.courseDAO = new CourseDAO(this.databaseManager, courseCache, locationCache);
+        this.courseDAO = new CourseDAO(this, this.databaseManager, courseCache, locationCache);
         this.parkourManager = new ParkourManager(this, this.uiManager, courseCache, locationCache);
 
         // 3. Initialize database and load caches
@@ -76,7 +76,7 @@ public final class ParkourPlugin extends JavaPlugin {
         this.uiManager = new UIManager(this);
         this.locationCache = new LocationCache(this);
         this.courseCache = new CourseCache(this.databaseManager, getLogger());
-        this.courseDAO = new CourseDAO(this.databaseManager, this.courseCache, this.locationCache);
+        this.courseDAO = new CourseDAO(this, this.databaseManager, this.courseCache, this.locationCache);
         this.parkourManager = new ParkourManager(this, this.uiManager, this.courseCache, this.locationCache);
 
         // Reload caches

--- a/src/main/java/com/oceanami/parkour/cache/CourseCache.java
+++ b/src/main/java/com/oceanami/parkour/cache/CourseCache.java
@@ -13,6 +13,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * Thread-safe cache of courses. Backed by a {@link ConcurrentHashMap} so it can be
+ * accessed safely from asynchronous tasks.
+ */
 public class CourseCache {
 
     private final Map<String, Course> courseCache = new ConcurrentHashMap<>();

--- a/src/main/java/com/oceanami/parkour/database/CourseDAO.java
+++ b/src/main/java/com/oceanami/parkour/database/CourseDAO.java
@@ -3,107 +3,189 @@ package com.oceanami.parkour.database;
 import com.oceanami.parkour.cache.CourseCache;
 import com.oceanami.parkour.manager.LocationCache;
 import com.oceanami.parkour.model.Course;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.plugin.java.JavaPlugin;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
 
 public class CourseDAO {
 
+    private final JavaPlugin plugin;
     private final DatabaseManager databaseManager;
     private final CourseCache courseCache;
     private final LocationCache locationCache;
 
-    public CourseDAO(DatabaseManager databaseManager, CourseCache courseCache, LocationCache locationCache) {
+    public CourseDAO(JavaPlugin plugin, DatabaseManager databaseManager, CourseCache courseCache, LocationCache locationCache) {
+        this.plugin = plugin;
         this.databaseManager = databaseManager;
         this.courseCache = courseCache;
         this.locationCache = locationCache;
     }
 
-    public void createCourse(String courseName) throws SQLException {
-        String sql = "INSERT INTO courses (name, ready) VALUES (?, ?)";
-        try (Connection conn = databaseManager.getConnection();
-             PreparedStatement pstmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
-            pstmt.setString(1, courseName);
-            pstmt.setBoolean(2, false);
-            int affectedRows = pstmt.executeUpdate();
+    public CompletableFuture<Void> createCourse(String courseName) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            String sql = "INSERT INTO courses (name, ready) VALUES (?, ?)";
+            try (Connection conn = databaseManager.getConnection();
+                 PreparedStatement pstmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+                pstmt.setString(1, courseName);
+                pstmt.setBoolean(2, false);
+                int affectedRows = pstmt.executeUpdate();
 
-            if (affectedRows > 0) {
-                try (ResultSet generatedKeys = pstmt.getGeneratedKeys()) {
-                    if (generatedKeys.next()) {
-                        int id = generatedKeys.getInt(1);
-                        Course newCourse = new Course(id, courseName, false);
-                        courseCache.addCourse(newCourse);
+                if (affectedRows > 0) {
+                    try (ResultSet generatedKeys = pstmt.getGeneratedKeys()) {
+                        if (generatedKeys.next()) {
+                            int id = generatedKeys.getInt(1);
+                            Course newCourse = new Course(id, courseName, false);
+                            Bukkit.getScheduler().runTask(plugin, () -> {
+                                courseCache.addCourse(newCourse);
+                                future.complete(null);
+                            });
+                            return;
+                        }
                     }
                 }
+                Bukkit.getScheduler().runTask(plugin, () -> future.complete(null));
+            } catch (SQLException e) {
+                plugin.getLogger().log(Level.SEVERE, "Could not create course", e);
+                future.completeExceptionally(e);
             }
-        }
+        });
+        return future;
     }
 
-    public Optional<Integer> getCourseId(String courseName) throws SQLException {
-        String sql = "SELECT id FROM courses WHERE name = ?";
-        try (Connection conn = databaseManager.getConnection();
-             PreparedStatement pstmt = conn.prepareStatement(sql)) {
-            pstmt.setString(1, courseName);
-            ResultSet rs = pstmt.executeQuery();
-            if (rs.next()) {
-                return Optional.of(rs.getInt("id"));
+    public CompletableFuture<Void> setStartLocation(int courseId, String courseName, Location loc) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            try {
+                saveLocation(courseId, "START", 0, loc);
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    locationCache.addStartLocation(courseName, loc);
+                    future.complete(null);
+                });
+            } catch (SQLException e) {
+                plugin.getLogger().log(Level.SEVERE, "Could not set start location", e);
+                future.completeExceptionally(e);
             }
-        }
-        return Optional.empty();
+        });
+        return future;
     }
 
-    public void setStartLocation(int courseId, String courseName, Location loc) throws SQLException {
-        saveLocation(courseId, "START", 0, loc);
-        locationCache.addStartLocation(courseName, loc);
-    }
-
-    public void setFinishLocation(int courseId, String courseName, Location loc) throws SQLException {
-        saveLocation(courseId, "FINISH", 0, loc);
-        locationCache.addFinishLocation(courseName, loc);
-    }
-
-    public void addCheckpoint(int courseId, String courseName, int order, Location loc) throws SQLException {
-        saveLocation(courseId, "CHECKPOINT", order, loc);
-        locationCache.addCheckpoint(courseName, order, loc);
-    }
-
-    public void setCustomRestartPoint(int courseId, String courseName, Location loc) throws SQLException {
-        saveLocation(courseId, "CUSTOM_RESTART", 0, loc);
-        locationCache.addCustomRestartPoint(courseName, loc);
-    }
-
-    public void setCustomResetPoint(int courseId, String courseName, Location loc) throws SQLException {
-        saveLocation(courseId, "CUSTOM_RESET", 0, loc);
-        locationCache.addCustomResetPoint(courseName, loc);
-    }
-
-    public int getCheckpointCount(int courseId) throws SQLException {
-        String sql = "SELECT COUNT(*) AS count FROM locations WHERE course_id = ? AND type = 'CHECKPOINT'";
-        try (Connection conn = databaseManager.getConnection();
-             PreparedStatement pstmt = conn.prepareStatement(sql)) {
-            pstmt.setInt(1, courseId);
-            ResultSet rs = pstmt.executeQuery();
-            if (rs.next()) {
-                return rs.getInt("count");
+    public CompletableFuture<Void> setFinishLocation(int courseId, String courseName, Location loc) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            try {
+                saveLocation(courseId, "FINISH", 0, loc);
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    locationCache.addFinishLocation(courseName, loc);
+                    future.complete(null);
+                });
+            } catch (SQLException e) {
+                plugin.getLogger().log(Level.SEVERE, "Could not set finish location", e);
+                future.completeExceptionally(e);
             }
-        }
-        return 0;
+        });
+        return future;
     }
 
-    public void setCourseReady(String courseName) throws SQLException {
-        String sql = "UPDATE courses SET ready = ? WHERE name = ?";
-        try (Connection conn = databaseManager.getConnection();
-             PreparedStatement pstmt = conn.prepareStatement(sql)) {
-            pstmt.setBoolean(1, true);
-            pstmt.setString(2, courseName);
-            pstmt.executeUpdate();
-            courseCache.getCourse(courseName).ifPresent(course -> course.setReady(true));
-        }
+    public CompletableFuture<Void> addCheckpoint(int courseId, String courseName, int order, Location loc) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            try {
+                saveLocation(courseId, "CHECKPOINT", order, loc);
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    locationCache.addCheckpoint(courseName, order, loc);
+                    future.complete(null);
+                });
+            } catch (SQLException e) {
+                plugin.getLogger().log(Level.SEVERE, "Could not add checkpoint", e);
+                future.completeExceptionally(e);
+            }
+        });
+        return future;
+    }
+
+    public CompletableFuture<Void> setCustomRestartPoint(int courseId, String courseName, Location loc) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            try {
+                saveLocation(courseId, "CUSTOM_RESTART", 0, loc);
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    locationCache.addCustomRestartPoint(courseName, loc);
+                    future.complete(null);
+                });
+            } catch (SQLException e) {
+                plugin.getLogger().log(Level.SEVERE, "Could not set custom restart point", e);
+                future.completeExceptionally(e);
+            }
+        });
+        return future;
+    }
+
+    public CompletableFuture<Void> setCustomResetPoint(int courseId, String courseName, Location loc) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            try {
+                saveLocation(courseId, "CUSTOM_RESET", 0, loc);
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    locationCache.addCustomResetPoint(courseName, loc);
+                    future.complete(null);
+                });
+            } catch (SQLException e) {
+                plugin.getLogger().log(Level.SEVERE, "Could not set custom reset point", e);
+                future.completeExceptionally(e);
+            }
+        });
+        return future;
+    }
+
+    public CompletableFuture<Integer> getCheckpointCount(int courseId) {
+        CompletableFuture<Integer> future = new CompletableFuture<>();
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            String sql = "SELECT COUNT(*) AS count FROM locations WHERE course_id = ? AND type = 'CHECKPOINT'";
+            try (Connection conn = databaseManager.getConnection();
+                 PreparedStatement pstmt = conn.prepareStatement(sql)) {
+                pstmt.setInt(1, courseId);
+                ResultSet rs = pstmt.executeQuery();
+                int count = 0;
+                if (rs.next()) {
+                    count = rs.getInt("count");
+                }
+                future.complete(count);
+            } catch (SQLException e) {
+                plugin.getLogger().log(Level.SEVERE, "Could not get checkpoint count", e);
+                future.completeExceptionally(e);
+            }
+        });
+        return future;
+    }
+
+    public CompletableFuture<Void> setCourseReady(String courseName) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            String sql = "UPDATE courses SET ready = ? WHERE name = ?";
+            try (Connection conn = databaseManager.getConnection();
+                 PreparedStatement pstmt = conn.prepareStatement(sql)) {
+                pstmt.setBoolean(1, true);
+                pstmt.setString(2, courseName);
+                pstmt.executeUpdate();
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    courseCache.getCourse(courseName).ifPresent(course -> course.setReady(true));
+                    future.complete(null);
+                });
+            } catch (SQLException e) {
+                plugin.getLogger().log(Level.SEVERE, "Could not set course ready", e);
+                future.completeExceptionally(e);
+            }
+        });
+        return future;
     }
 
     private void saveLocation(int courseId, String type, int order, Location loc) throws SQLException {

--- a/src/main/java/com/oceanami/parkour/database/PlayerTimeDAO.java
+++ b/src/main/java/com/oceanami/parkour/database/PlayerTimeDAO.java
@@ -1,8 +1,11 @@
 package com.oceanami.parkour.database;
 
 import com.oceanami.parkour.ParkourPlugin;
+import com.oceanami.parkour.cache.CourseCache;
+import com.oceanami.parkour.model.Course;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.sql.Connection;
@@ -10,46 +13,61 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Optional;
+import java.util.logging.Level;
 
+/**
+ * Handles persistence of player best times. All database operations are executed asynchronously,
+ * and any interaction with the Bukkit API is dispatched back onto the main server thread.
+ */
 public class PlayerTimeDAO {
 
+    private final ParkourPlugin plugin;
     private final DatabaseManager dbManager;
-    private final CourseDAO courseDAO;
+    private final CourseCache courseCache;
 
-    public PlayerTimeDAO(ParkourPlugin plugin) {
+    public PlayerTimeDAO(ParkourPlugin plugin, CourseCache courseCache) {
+        this.plugin = plugin;
         this.dbManager = plugin.getDatabaseManager();
-        this.courseDAO = plugin.getCourseDAO();
+        this.courseCache = courseCache;
     }
 
     public void savePlayerTime(Player player, String courseName, long timeMillis) {
-        try {
-            Optional<Integer> courseIdOpt = courseDAO.getCourseId(courseName);
-            if (courseIdOpt.isEmpty()) {
-                player.sendMessage(Component.text("Error: The course '" + courseName + "' no longer exists.").color(NamedTextColor.RED));
-                return;
-            }
-            int courseId = courseIdOpt.get();
-
-            Optional<Long> existingTime = getPlayerTime(player.getUniqueId().toString(), courseId);
-
-            if (existingTime.isEmpty() || timeMillis < existingTime.get()) {
-                String sql = "REPLACE INTO parkour_times (player_uuid, player_name, course_id, time_millis) VALUES (?, ?, ?, ?)";
-                try (Connection conn = dbManager.getConnection();
-                     PreparedStatement pstmt = conn.prepareStatement(sql)) {
-                    pstmt.setString(1, player.getUniqueId().toString());
-                    pstmt.setString(2, player.getName());
-                    pstmt.setInt(3, courseId);
-                    pstmt.setLong(4, timeMillis);
-                    pstmt.executeUpdate();
-                    player.sendMessage(Component.text("Congratulations! You set a new personal best!").color(NamedTextColor.GREEN));
-                }
-            } else {
-                player.sendMessage(Component.text("You did not beat your previous best time. Keep trying!").color(NamedTextColor.YELLOW));
-            }
-        } catch (SQLException e) {
-            player.sendMessage(Component.text("Could not save your time due to a database error.").color(NamedTextColor.RED));
-            e.printStackTrace();
+        Optional<Course> courseOpt = courseCache.getCourse(courseName);
+        if (courseOpt.isEmpty()) {
+            player.sendMessage(Component.text("Error: The course '" + courseName + "' no longer exists.").color(NamedTextColor.RED));
+            return;
         }
+        int courseId = courseOpt.get().getId();
+
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            try {
+                Optional<Long> existingTime = getPlayerTime(player.getUniqueId().toString(), courseId);
+
+                if (existingTime.isEmpty() || timeMillis < existingTime.get()) {
+                    String sql = "REPLACE INTO parkour_times (player_uuid, player_name, course_id, time_millis) VALUES (?, ?, ?, ?)";
+                    try (Connection conn = dbManager.getConnection();
+                         PreparedStatement pstmt = conn.prepareStatement(sql)) {
+                        pstmt.setString(1, player.getUniqueId().toString());
+                        pstmt.setString(2, player.getName());
+                        pstmt.setInt(3, courseId);
+                        pstmt.setLong(4, timeMillis);
+                        pstmt.executeUpdate();
+                    }
+                    Bukkit.getScheduler().runTask(plugin, () ->
+                        player.sendMessage(Component.text("Congratulations! You set a new personal best!").color(NamedTextColor.GREEN))
+                    );
+                } else {
+                    Bukkit.getScheduler().runTask(plugin, () ->
+                        player.sendMessage(Component.text("You did not beat your previous best time. Keep trying!").color(NamedTextColor.YELLOW))
+                    );
+                }
+            } catch (SQLException e) {
+                Bukkit.getScheduler().runTask(plugin, () ->
+                    player.sendMessage(Component.text("Could not save your time due to a database error.").color(NamedTextColor.RED))
+                );
+                plugin.getLogger().log(Level.SEVERE, "Could not save player time", e);
+            }
+        });
     }
 
     private Optional<Long> getPlayerTime(String uuid, int courseId) throws SQLException {

--- a/src/main/java/com/oceanami/parkour/manager/LocationCache.java
+++ b/src/main/java/com/oceanami/parkour/manager/LocationCache.java
@@ -14,6 +14,11 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
+/**
+ * Stores parkour-related locations. Internal maps are thread-safe and may be
+ * updated from asynchronous tasks. Returned {@link Location} objects must only
+ * be used on the main thread when interacting with the Bukkit API.
+ */
 public class LocationCache {
 
     private final ParkourPlugin plugin;

--- a/src/main/java/com/oceanami/parkour/manager/ParkourManager.java
+++ b/src/main/java/com/oceanami/parkour/manager/ParkourManager.java
@@ -16,6 +16,11 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Manages active parkour sessions. This manager is not thread-safe and should only be
+ * accessed from the Bukkit main thread. Any asynchronous callbacks must schedule their
+ * interactions back onto the main thread before invoking its methods.
+ */
 public class ParkourManager {
 
     private final ParkourPlugin plugin;
@@ -34,7 +39,7 @@ public class ParkourManager {
         this.locationCache = locationCache;
         this.playerSessions = new HashMap<>();
         this.effectsManager = new EffectsManager(plugin);
-        this.playerTimeDAO = new PlayerTimeDAO(plugin);
+        this.playerTimeDAO = new PlayerTimeDAO(plugin, courseCache);
         this.teleportOnStart = plugin.getConfig().getBoolean("teleport-on-start", true);
     }
 


### PR DESCRIPTION
## Summary
- Offload course and player time database work to asynchronous tasks with main-thread callbacks for cache and player updates
- Update commands to use async DAO APIs and document thread safety of caches and managers

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6896c47f5f388329a517fe56a1f63b69